### PR TITLE
doc: add link to `epic-analysis` tutorial documentation

### DIFF
--- a/_documentation/landingpage.md
+++ b/_documentation/landingpage.md
@@ -19,4 +19,5 @@ It only contains links to other tutorials and the [FAQ](https://eic.github.io/do
 1. [Geometry within dd4hep](https://eic.github.io/tutorial-geometry-development-using-dd4hep/ )
 1. [Simulation with ePIC singularity container](https://eic.github.io/tutorial-simulations-using-ddsim-and-geant4/)
 1. [Reconstruction framework](https://eic.github.io/tutorial-jana2/)
+1. [epic-analysis: A common analysis framework for (SI)DIS, Jets, and more](https://github.com/eic/epic-analysis/blob/main/README.md)
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Link to [epic-analysis documentation](https://github.com/eic/epic-analysis/blob/main/README.md) from the landing page. This link points to a `README`, which is the most up-to-date and easily maintainable documentation for `epic-analysis`.

The documentation is being streamlined for a tutorial presentation in https://github.com/eic/epic-analysis/pull/255.

From a maintenance point of view, I prefer to follow "DRY" and simply link the README, rather than creating a new, separate tutorial from the Carpentries template.

 
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no