### PR TITLE
feat: add our computing policies in the website (demo of external repo inclusion)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_policies"]
+	path = _policies
+	url = https://github.com/eic/policies

--- a/_config.yml
+++ b/_config.yml
@@ -1,78 +1,3 @@
-name: The EIC Software Website
-title: The EIC Software Website
-description: The EIC Software Website
-url: https://eic.github.io
-#
-excerpt_separator: <!--more-->
-timezone: America/New_York
-highlighter: rouge
-#
-markdown: kramdown
-future: true
-exclude: [vendor]
-
-##################################################################################
-# Important if we are not serving from the top folder - baseurl: /web            #
-# In that case, please make sure you use the "relative_path" directive           #
-# everywhere you include various site URLs in your pages.                        #
-#                                                                                #
-# Currently serving from the top folder i.e.                                     #
-# in this case this does not apply until further notice.                         #
-##################################################################################
-
-# Custom helper variables:
-blank: 'target="_blank"'
-
-
-# Layout
-tablepadding: ' '
-
-# Decorative elements
-eic_logo: /assets/images/site/EIClogo_small.png
-splash: /assets/images/site/ion-collision-xparent-cropped.png
-
-# Icons:
-home_icon: /assets/images/site/icons/house-32.png
-external_icon: /assets/images/site/icons/external-link-32.png
-
-software_icon: /assets/images/site/icons/console-32.png
-resources_icon: /assets/images/site/icons/cog-32.png
-#activities_icon: /assets/images/site/icons/today-32.png
-activities_icon: /assets/images/site/icons/light-bulb-5-32.png
-organization_icon: /assets/images/site/icons/flow-chart-32.png
-documentation_icon: /assets/images/site/icons/literature-32.png
-about_icon: /assets/images/site/icons/light-bulb-5-32.png
-
-
-# Development:
-display_news: yes
-#
-plugins:
-  - jekyll-mentions
-  - jekyll-sitemap
-  - jekyll-redirect-from
-
-#
-collections:
-  software:
-    output: true
-    permalink: /software/:title.html
-  resources:
-    output: true
-    permalink: /resources/:title.html
-  activities:
-    output: true
-    permalink: /activities/:title.html
-  organization:
-    output: true
-    permalink: /organization/:title.html
-  documentation:
-    output: true
-    permalink: /documentation/:title.html
-  about:
-    output: true
-    permalink: /about/:title.html#
-#
 #
 name: The EIC Software Website
 title: The EIC Software Website
@@ -114,6 +39,7 @@ software_icon: /assets/images/site/icons/console-32.png
 resources_icon: /assets/images/site/icons/cog-32.png
 activities_icon: /assets/images/site/icons/light-bulb-5-32.png
 organization_icon: /assets/images/site/icons/flow-chart-32.png
+policies_icon: /assets/images/site/icons/cog-32.png
 documentation_icon: /assets/images/site/icons/literature-32.png
 about_icon: /assets/images/site/icons/light-bulb-5-32.png
 
@@ -143,6 +69,9 @@ collections:
   documentation:
     output: true
     permalink: /documentation/:title.html
+  policies:
+    output: true
+    permalink: /policies/:title.html
   about:
     output: true
     permalink: /about/:title.html

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -99,6 +99,16 @@
 #     full: Get Involved
 #       div: yes
 
+### Policies
+#
+- name: policies
+  full: Policies
+  submenus:
+    - name: simulation_production_strategy
+      full: Simulation Production Strategy
+    - name: source_code_management
+      full: Source Code Management
+
 ### Documentation
 #
 - name: documentation

--- a/_includes/layouts/autodrop_data.md
+++ b/_includes/layouts/autodrop_data.md
@@ -4,6 +4,7 @@
 {% when "resources" %}   {% assign theCollection=site.resources %}   {% assign icon=site.resources_icon %}
 {% when "activities" %}  {% assign theCollection=site.activities %}  {% assign icon=site.activities_icon %}
 {% when "organization" %}{% assign theCollection=site.organization %}{% assign icon=site.organization_icon %}
+{% when "policies" %}    {% assign theCollection=site.policies %}    {% assign icon=site.policies_icon %}
 {% when "documentation" %}{% assign theCollection=site.documentation %}{% assign icon=site.documentation_icon %}
 {% when "about" %}       {% assign theCollection=site.about %}            {% assign icon=site.about_icon %}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This inserts the https://github.com/eic/policies repository into the eic.github.io webpage under policies/, with inclusion in the menu structure.

Looks like this:
![image](https://github.com/eic/eic.github.io/assets/4656391/bdacd085-0665-4527-81b1-9bc4da1f4f0a)

Fixes #29 