### PR TITLE
feat: replace eicug-computing-infrastructure-support@eicug.org

### DIFF
--- a/_about/contact.md
+++ b/_about/contact.md
@@ -8,7 +8,7 @@ layout: default
 This site is work in progress. Contributions and suggestions from the EICUG members will be appreciated.
 
 For questions regarding contributions to this site and its functionality please contact
-<a href="mailto:eicug-computing-infrastructure-support@eicug.org">
-eicug-computing-infrastructure-support@eicug.org</a>
+<a href="mailto:eic-software-l-request@lists.bnl.gov">
+eic-software-l-request@lists.bnl.gov</a>
 
 Webmaster: <a href="mailto:potekhin@bnl.gov">Maxim Potekhin</a>

--- a/_organization/communication.md
+++ b/_organization/communication.md
@@ -15,6 +15,6 @@ Google Groups are used to manage mailing lists. Please contact the <a href="mail
 <tr><td>The EICUG Software Group</td><td><a href="mailto:eicug-software@eicug.org">eicug-software@eicug.org</a></td></tr>
 <tr><td>The Core Team</td><td><a href="mailto:eicug-software-core@eicug.org">eicug-software-core@eicug.org</a></td></tr>
 <tr><td>Software support</td><td><a href="mailto:software-support@eicug.org">software-support@eicug.org</a></td></tr>
-<tr><td>Infrastructure support</td><td><a href="mailto:eicug-computing-infrastructure-support@eicug.org">eicug-computing-infrastructure-support@eicug.org</a></td></tr>
+<tr><td>Infrastructure support</td><td><a href="mailto:eic-software-l-request@lists.bnl.gov">eic-software-l-request@lists.bnl.gov</a></td></tr>
 </table>
 

--- a/_software/github.md
+++ b/_software/github.md
@@ -34,7 +34,7 @@ available for free on the Git website.
 
 ##### GitHub Organization {#organization}
 
-The {% include navigation/findlink.md name='github' tag='EIC GitHub Organization' %} is available for the whole EICUG. For membership, please send your GitHub username to [eicug-computing-infrastructure-support@eicug.org](mailto:eicug-computing-infrastructure-support@eicug.org?subject=GitHub%20Account)
+The {% include navigation/findlink.md name='github' tag='EIC GitHub Organization' %} is available for the whole EICUG. For membership, please send your GitHub username to [eic-software-l-request@lists.bnl.gov](mailto:eic-software-l-request@lists.bnl.gov?subject=GitHub%20Account)
 
 ##### GitHub Guidelines {#guidelines}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This updates some defunct email addresses.