### PR TITLE
add rse open options in list-file-replicas

### DIFF
--- a/_resources/production_file.md
+++ b/_resources/production_file.md
@@ -66,12 +66,11 @@ To see what files are available and how to access it use Rucio.
 - **Find location of files**:
     command: `rucio list-file-replicas --protocol root --pfns <did>`
     ```shell
-     $ rucio list-file-replicas --protocol root --pfns  epic:/RECO/25.01.1/epic_craterlake/DIS/NC/10x100/minQ2=10/pythia8NCDIS_10x100_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_5.0255.eicrecon.tree.edm4eic.root
+     $ rucio list-file-replicas --protocol root --pfns --rses isopen epic:/RECO/25.01.1/epic_craterlake/DIS/NC/10x100/minQ2=10/pythia8NCDIS_10x100_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_5.0255.eicrecon.tree.edm4eic.root
 
-    root://sca2302.jlab.org:10940//mss/eic/EPIC//RECO/25.01.1/epic_craterlake/DIS/NC/10x100/minQ2=10/pythia8NCDIS_10x100_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_5.0255.eicrecon.tree.edm4eic.root
     root://dtn-rucio.jlab.org:1094//volatile/eic/EPIC//RECO/25.01.1/epic_craterlake/DIS/NC/10x100/minQ2=10/pythia8NCDIS_10x100_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_5.0255.eicrecon.tree.edm4eic.root
     ```
-    Here, the first entry is a tape replica and is not externally accessible. The second URI is pointing to the on-disk XRootD. `rucio download` will automatically pick accessible entry.
+    If you see multiple replicas you can use any one of those.
 
 #### Access methods for production files include:
 

--- a/_resources/production_file.md
+++ b/_resources/production_file.md
@@ -70,7 +70,7 @@ To see what files are available and how to access it use Rucio.
 
     root://dtn-rucio.jlab.org:1094//volatile/eic/EPIC//RECO/25.01.1/epic_craterlake/DIS/NC/10x100/minQ2=10/pythia8NCDIS_10x100_minQ2=10_beamEffects_xAngle=-0.025_hiDiv_5.0255.eicrecon.tree.edm4eic.root
     ```
-    If you see multiple replicas you can use any one of those.
+    If you see multiple replicas you can use any one of those. You can check using `rucio list-rses --rses isopen` for a full list of RSE's.
 
 #### Access methods for production files include:
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Remove confusion on which replica to use in list-file-replicas.

introduce rse attribute isopen which only list replica in open (no auth ) read replicas.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
